### PR TITLE
add jsonpointer supporting multiple json path

### DIFF
--- a/mockserver/swagger/refutil/jsonpointer.go
+++ b/mockserver/swagger/refutil/jsonpointer.go
@@ -1,0 +1,272 @@
+package refutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-openapi/jsonpointer"
+)
+
+type offsetProgress struct {
+	decodedToken []string
+	tkIndex      int
+	offset       int64
+	finished     bool
+}
+
+// return map[p.String()]offset
+// use a map to keep progress of every pointer and do the parse in one pass.
+// use `-1` as error result.
+func JSONPointerOffsetMulti(ps []jsonpointer.Pointer, document string) (map[string]int64, error) {
+	dec := json.NewDecoder(strings.NewReader(document))
+
+	progressMap := make(map[string]offsetProgress, 0)
+	for _, p := range ps {
+		t := p.DecodedTokens()
+		if len(t) > 0 {
+			progressMap[p.String()] = offsetProgress{
+				decodedToken: t,
+				tkIndex:      0,
+				offset:       0,
+				finished:     false,
+			}
+		}
+	}
+
+	tks := make(map[string]string, 0)
+	for k, p := range progressMap {
+		if len(p.decodedToken) > 0 {
+			tks[k] = p.decodedToken[0]
+		}
+	}
+
+	tk, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	switch tk := tk.(type) {
+	case json.Delim:
+		switch tk {
+		case '{':
+			progressMap, err = offsetSingleObjectForMulti(dec, progressMap, 0)
+			if err != nil {
+				return nil, err
+			}
+		case '[':
+			progressMap, err = offsetSingleArrayForMulti(dec, progressMap, 0)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("invalid token %#v", tk)
+		}
+	default:
+	}
+
+	result := make(map[string]int64)
+	errKey := make([]string, 0)
+	for k, p := range progressMap {
+		if p.finished {
+			result[k] = p.offset
+		} else {
+			result[k] = 0 // not found
+			errKey = append(errKey, k)
+		}
+	}
+
+	if len(errKey) > 0 {
+		return nil, fmt.Errorf("token reference %q not found", errKey)
+	}
+
+	return result, nil
+}
+
+func offsetSingleObjectForMulti(dec *json.Decoder, progressMap map[string]offsetProgress, depth int) (map[string]offsetProgress, error) {
+	tks := make(map[string]string, 0)
+	for k, p := range progressMap {
+		if p.tkIndex == depth {
+			tks[k] = p.decodedToken[p.tkIndex]
+		}
+	}
+	if len(tks) == 0 {
+		return progressMap, nil
+	}
+
+	// used for next level call
+	var nextLevelProgress map[string]offsetProgress
+	// first token after a key needs special handling
+	isFirstTokenAfterHit := false
+	for dec.More() {
+		tmpProgressMap := nextLevelProgress
+		nextLevelProgress = make(map[string]offsetProgress, 0)
+		hit := false
+		offset := dec.InputOffset()
+		tk, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		switch tk := tk.(type) {
+		case json.Delim:
+			switch tk {
+			case '{':
+				if isFirstTokenAfterHit {
+					nextLevelProgress, err = offsetSingleObjectForMulti(dec, tmpProgressMap, depth+1)
+					if err != nil {
+						return nil, err
+					}
+				} else if err := drainSingle(dec); err != nil {
+					return nil, err
+				}
+			case '[':
+				if isFirstTokenAfterHit {
+					nextLevelProgress, err = offsetSingleArrayForMulti(dec, tmpProgressMap, depth+1)
+					if err != nil {
+						return nil, err
+					}
+				} else if err := drainSingle(dec); err != nil {
+					return nil, err
+				}
+			}
+		case string:
+			for k, t := range tks {
+				if tk == t {
+					p := progressMap[k]
+					p.offset = offset
+					if p.tkIndex == len(p.decodedToken)-1 {
+						p.finished = true
+					}
+					if p.tkIndex < len(p.decodedToken)-1 {
+						p.tkIndex++
+					}
+					progressMap[k] = p
+					nextLevelProgress[k] = p
+					isFirstTokenAfterHit = true
+					hit = true
+				}
+			}
+		default:
+		}
+		for k, p := range nextLevelProgress {
+			progressMap[k] = p
+		}
+		isFirstTokenAfterHit = hit
+	}
+	// Consumes the ending delim
+	if depth > 0 {
+		_, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return progressMap, nil
+}
+
+func offsetSingleArrayForMulti(dec *json.Decoder, progressMap map[string]offsetProgress, depth int) (map[string]offsetProgress, error) {
+	idxs := make(map[string]string, 0)
+	for k, p := range progressMap {
+		if p.tkIndex == depth {
+			idxs[k] = p.decodedToken[p.tkIndex]
+		}
+	}
+	if len(idxs) == 0 {
+		return progressMap, nil
+	}
+
+	var tmpProgressMap map[string]offsetProgress
+	for i := 0; dec.More(); i++ {
+		hit := false
+		tmpProgressMap = make(map[string]offsetProgress, 0)
+
+		offset := dec.InputOffset()
+		tk, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		for k, idx := range idxs {
+			idx, err := strconv.Atoi(idx)
+			if err != nil {
+				return nil, err
+			}
+			if i == idx {
+				p := progressMap[k]
+				p.offset = offset
+				if p.tkIndex == len(p.decodedToken)-1 {
+					p.finished = true
+				}
+				if p.tkIndex < len(p.decodedToken)-1 {
+					p.tkIndex++
+				}
+				progressMap[k] = p
+				tmpProgressMap[k] = p
+				hit = true
+			}
+		}
+
+		switch tk := tk.(type) {
+		case json.Delim:
+			switch tk {
+			case '{':
+				if hit {
+					tmpProgressMap, err = offsetSingleObjectForMulti(dec, tmpProgressMap, depth+1)
+					if err != nil {
+						return nil, err
+					}
+				} else if err := drainSingle(dec); err != nil {
+					return nil, err
+				}
+			case '[':
+				if hit {
+					tmpProgressMap, err = offsetSingleArrayForMulti(dec, tmpProgressMap, depth+1)
+					if err != nil {
+						return nil, err
+					}
+				} else if err := drainSingle(dec); err != nil {
+					return nil, err
+				}
+			}
+		}
+		for t, p := range tmpProgressMap {
+			progressMap[t] = p
+		}
+	}
+
+	// Consumes the ending delimF
+	if depth > 0 {
+		_, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return progressMap, nil
+}
+
+// drainSingle drains a single level of object or array.
+// The decoder has to guarantee the begining delim (i.e. '{' or '[') has been consumed.
+func drainSingle(dec *json.Decoder) error {
+	for dec.More() {
+		tk, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		switch tk := tk.(type) {
+		case json.Delim:
+			switch tk {
+			case '{':
+				if err := drainSingle(dec); err != nil {
+					return err
+				}
+			case '[':
+				if err := drainSingle(dec); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	// Consumes the ending delim
+	if _, err := dec.Token(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/mockserver/swagger/refutil/jsonpointer.go
+++ b/mockserver/swagger/refutil/jsonpointer.go
@@ -35,13 +35,6 @@ func JSONPointerOffsetMulti(ps []jsonpointer.Pointer, document string) (map[stri
 		}
 	}
 
-	tks := make(map[string]string, 0)
-	for k, p := range progressMap {
-		if len(p.decodedToken) > 0 {
-			tks[k] = p.decodedToken[0]
-		}
-	}
-
 	tk, err := dec.Token()
 	if err != nil {
 		return nil, err
@@ -142,7 +135,6 @@ func offsetSingleObjectForMulti(dec *json.Decoder, progressMap map[string]offset
 					}
 					progressMap[k] = p
 					nextLevelProgress[k] = p
-					isFirstTokenAfterHit = true
 					hit = true
 				}
 			}

--- a/mockserver/swagger/refutil/jsonpointer.go
+++ b/mockserver/swagger/refutil/jsonpointer.go
@@ -17,8 +17,6 @@ type offsetProgress struct {
 }
 
 // return map[p.String()]offset
-// use a map to keep progress of every pointer and do the parse in one pass.
-// use `-1` as error result.
 func JSONPointerOffsetMulti(ps []jsonpointer.Pointer, document string) (map[string]int64, error) {
 	dec := json.NewDecoder(strings.NewReader(document))
 

--- a/mockserver/swagger/refutil/jsonpointer_test.go
+++ b/mockserver/swagger/refutil/jsonpointer_test.go
@@ -1,0 +1,104 @@
+package refutil
+
+import (
+	"testing"
+
+	"github.com/go-openapi/jsonpointer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSONPointerOffsetMulti(t *testing.T) {
+	cases := []struct {
+		name     string
+		ptr      []string
+		input    string
+		offset   map[string]int64
+		hasError bool
+	}{
+		{
+			name: "object key",
+			ptr: []string{
+				"/foo/bar",
+				"/foo/baz",
+				"/foo",
+			},
+			input: `{"foo": {"bar": 21, "baz": 42, "bed": 11}, "zoo":"1"}`,
+			offset: map[string]int64{
+				"/foo/bar": 9,
+				"/foo/baz": 18,
+				"/foo":     1,
+			},
+		},
+		{
+			name: "array index",
+			ptr: []string{
+				"/0/0",
+				"/0/1",
+				"/1/0",
+				"/1/1",
+			},
+			input: `[[1,2], [3,4]]`,
+			offset: map[string]int64{
+				"/0/0": 2,
+				"/0/1": 3,
+				"/1/0": 9,
+				"/1/1": 10,
+			},
+		},
+		{
+			name: "mix array index and object key",
+			ptr: []string{
+				"/0/1/foo/0",
+			},
+			input: `[[1, {"foo": ["a", "b"]}], [3, 4]]`,
+			offset: map[string]int64{
+				"/0/1/foo/0": 14,
+			},
+		},
+		{
+			name: "nonexist object key",
+			ptr: []string{
+				"/foo/baz",
+			},
+			input:    `{"foo": {"bar": 21}}`,
+			hasError: true,
+		},
+		{
+			name: "nonexist array index",
+			ptr: []string{
+				"/0/2",
+			},
+			input:    `[[1,2], [3,4]]`,
+			hasError: true,
+		},
+		{
+			name: "encoded reference",
+			ptr: []string{
+				"/paths/~1p~1{}/get",
+			},
+			input: `{"paths": {"foo": {"bar": 123, "baz": {}}, "/p/{}": {"get": {}}}}`,
+			offset: map[string]int64{
+				"/paths/~1p~1{}/get": 53,
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ptrs := make([]jsonpointer.Pointer, 0)
+			for _, p := range tt.ptr {
+				ptr, err := jsonpointer.New(p)
+				assert.NoError(t, err)
+				ptrs = append(ptrs, ptr)
+			}
+			offset, err := JSONPointerOffsetMulti(ptrs, tt.input)
+			if tt.hasError {
+				assert.Error(t, err)
+				return
+			}
+			t.Log(offset, err)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.offset, offset)
+		})
+	}
+}


### PR DESCRIPTION
test
---
```
=== RUN   TestJSONPointerOffsetMulti
--- PASS: TestJSONPointerOffsetMulti (0.00s)
=== RUN   TestJSONPointerOffsetMulti/object_key
    jsonpointer_test.go:161: map[/foo:1 /foo/bar:9 /foo/baz:18] <nil>
    --- PASS: TestJSONPointerOffsetMulti/object_key (0.00s)
=== RUN   TestJSONPointerOffsetMulti/array_index
    jsonpointer_test.go:161: map[/0/0:2 /0/1:3 /1/0:9 /1/1:10] <nil>
    --- PASS: TestJSONPointerOffsetMulti/array_index (0.00s)
=== RUN   TestJSONPointerOffsetMulti/mix_array_index_and_object_key
    jsonpointer_test.go:161: map[/0/1/foo/0:14] <nil>
    --- PASS: TestJSONPointerOffsetMulti/mix_array_index_and_object_key (0.00s)
=== RUN   TestJSONPointerOffsetMulti/nonexist_object_key
    --- PASS: TestJSONPointerOffsetMulti/nonexist_object_key (0.00s)
=== RUN   TestJSONPointerOffsetMulti/nonexist_array_index
    --- PASS: TestJSONPointerOffsetMulti/nonexist_array_index (0.00s)
=== RUN   TestJSONPointerOffsetMulti/encoded_reference
    jsonpointer_test.go:161: map[/paths/~1p~1{}/get:53] <nil>
    --- PASS: TestJSONPointerOffsetMulti/encoded_reference (0.00s)
PASS
```