### PR TITLE
Refactor synth: Extract synth to be monomorphization + synth

### DIFF
--- a/mockserver/server.go
+++ b/mockserver/server.go
@@ -194,8 +194,17 @@ func (srv *Server) synthResponse(r *http.Request, synthOpt *swagger.SynthesizerO
 	if err := exp.Expand(); err != nil {
 		return nil, nil, err
 	}
-	syn := swagger.NewSynthesizer(exp.Root(), &srv.rnd, synthOpt)
-	return syn.Synthesize(), exp.Root(), nil
+	propInstances := swagger.Monomorphization(exp.Root())
+	var results []interface{}
+	for _, propInstance := range propInstances {
+		propInstance := propInstance
+		syn, err := swagger.NewSynthesizer(&propInstance, &srv.rnd, synthOpt)
+		if err != nil {
+			return nil, nil, err
+		}
+		results = append(results, syn.Synthesize())
+	}
+	return results, exp.Root(), nil
 }
 
 func (srv *Server) selResponse(resps []interface{}, ov *Override) ([]byte, error) {

--- a/mockserver/swagger/catesian_product.go
+++ b/mockserver/swagger/catesian_product.go
@@ -1,0 +1,65 @@
+package swagger
+
+import "sort"
+
+func CatesianProduct[T any](params ...[]T) [][]T {
+	if params == nil {
+		return nil
+	}
+	result := [][]T{}
+	for _, param := range params {
+		if len(param) != 0 {
+			newresult := [][]T{}
+			for _, v := range param {
+				if len(result) == 0 {
+					res := []T{v}
+					newresult = append(newresult, res)
+				} else {
+					for _, res := range result {
+						nres := make([]T, len(res))
+						copy(nres, res)
+						nres = append(nres, v)
+						newresult = append(newresult, nres)
+					}
+				}
+			}
+			result = newresult
+		}
+	}
+	return result
+}
+
+func CatesianProductMap[T any](params map[string][]T) []map[string]T {
+	if params == nil {
+		return nil
+	}
+	result := []map[string]T{}
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		param := params[k]
+		if len(param) != 0 {
+			newresult := []map[string]T{}
+			for _, v := range param {
+				if len(result) == 0 {
+					res := map[string]T{k: v}
+					newresult = append(newresult, res)
+				} else {
+					for _, res := range result {
+						nres := map[string]T{}
+						for kk, vv := range res {
+							nres[kk] = vv
+						}
+						nres[k] = v
+						newresult = append(newresult, nres)
+					}
+				}
+			}
+			result = newresult
+		}
+	}
+	return result
+}

--- a/mockserver/swagger/catesian_product_test.go
+++ b/mockserver/swagger/catesian_product_test.go
@@ -1,0 +1,127 @@
+package swagger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatesianProduct(t *testing.T) {
+	cases := []struct {
+		name   string
+		params [][]interface{}
+		expect [][]interface{}
+	}{
+		{
+			name:   "nil",
+			params: nil,
+			expect: nil,
+		},
+		{
+			name:   "empty",
+			params: [][]interface{}{},
+			expect: [][]interface{}{},
+		},
+		{
+			name:   "[1]",
+			params: [][]interface{}{{1}},
+			expect: [][]interface{}{{1}},
+		},
+		{
+			name:   "[1, 2]",
+			params: [][]interface{}{{1, 2}},
+			expect: [][]interface{}{{1}, {2}},
+		},
+		{
+			name:   "[1, 2] x [3]",
+			params: [][]interface{}{{1, 2}, {3}},
+			expect: [][]interface{}{{1, 3}, {2, 3}},
+		},
+		{
+			name:   "[1] x []",
+			params: [][]interface{}{{1}, {}},
+			expect: [][]interface{}{{1}},
+		},
+		{
+			name:   "[1, 2] x [3, 4] x [5, 6]",
+			params: [][]interface{}{{1, 2}, {3, 4}, {5, 6}},
+			expect: [][]interface{}{
+				{1, 3, 5},
+				{2, 3, 5},
+				{1, 4, 5},
+				{2, 4, 5},
+				{1, 3, 6},
+				{2, 3, 6},
+				{1, 4, 6},
+				{2, 4, 6},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expect, CatesianProduct(tt.params...))
+		})
+	}
+}
+
+func TestCatesianProductMap(t *testing.T) {
+	cases := []struct {
+		name   string
+		params map[string][]interface{}
+		expect []map[string]interface{}
+	}{
+		{
+			name:   "nil",
+			params: nil,
+			expect: nil,
+		},
+		{
+			name:   "empty",
+			params: map[string][]interface{}{},
+			expect: []map[string]interface{}{},
+		},
+		{
+			name:   "{a: []}",
+			params: map[string][]interface{}{"a": {}},
+			expect: []map[string]interface{}{},
+		},
+		{
+			name:   "{a: [1]}",
+			params: map[string][]interface{}{"a": {1}},
+			expect: []map[string]interface{}{{"a": 1}},
+		},
+		{
+			name:   "{a: [1, 2]}",
+			params: map[string][]interface{}{"a": {1, 2}},
+			expect: []map[string]interface{}{{"a": 1}, {"a": 2}},
+		},
+		{
+			name:   "{a: [1], b: []}",
+			params: map[string][]interface{}{"a": {1}, "b": {}},
+			expect: []map[string]interface{}{{"a": 1}},
+		},
+		{
+			name:   "{a: [1, 2]} x {b: [3]}",
+			params: map[string][]interface{}{"a": {1, 2}, "b": {3}},
+			expect: []map[string]interface{}{{"a": 1, "b": 3}, {"a": 2, "b": 3}},
+		},
+		{
+			name:   "{a: [1, 2]} x {b: [3]} x {c: [40, 50]}",
+			params: map[string][]interface{}{"a": {1, 2}, "b": {3}, "c": {40, 50}},
+			expect: []map[string]interface{}{
+				{"a": 1, "b": 3, "c": 40},
+				{"a": 2, "b": 3, "c": 40},
+				{"a": 1, "b": 3, "c": 50},
+				{"a": 2, "b": 3, "c": 50},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CatesianProductMap(tt.params)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}

--- a/mockserver/swagger/expander.go
+++ b/mockserver/swagger/expander.go
@@ -13,11 +13,8 @@ import (
 )
 
 type Expander struct {
-	// Operation ref
-	ref  spec.Ref
 	root *Property
 
-	// This map is not initialized until the first time failed to resolve the model by the discriminator enum value.
 	// The key represents each swagger spec
 	variantMaps map[string]VariantMap
 
@@ -50,7 +47,6 @@ func NewExpander(ref spec.Ref, opt *ExpanderOption) (*Expander, error) {
 	}
 
 	return &Expander{
-		ref: ref,
 		root: &Property{
 			Schema:      psch,
 			ref:         ownRef,
@@ -378,7 +374,6 @@ func (e *Expander) expandPropAsRegularObject(prop *Property) error {
 			continue
 		}
 		tmpExp := Expander{
-			ref: ownRef,
 			root: &Property{
 				Schema:      schema,
 				RootModel:   prop.RootModel,

--- a/mockserver/swagger/monomorphisizer.go
+++ b/mockserver/swagger/monomorphisizer.go
@@ -1,0 +1,65 @@
+package swagger
+
+import "sort"
+
+func Monomorphization(prop *Property) []Property {
+	var monomorph func(p *Property) []Property
+	monomorph = func(p *Property) []Property {
+		var result []Property
+		switch {
+		case p.Element != nil:
+			elements := monomorph(p.Element)
+			for _, elem := range elements {
+				elem := elem
+				np := *p
+				np.Element = &elem
+				result = append(result, np)
+			}
+		case p.Children != nil:
+			if len(p.Children) == 0 {
+				// empty object
+				np := *p
+				return []Property{np}
+			}
+
+			m := map[string][]Property{}
+			var keys []string
+			for k := range p.Children {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				m[k] = monomorph(p.Children[k])
+			}
+			for _, mm := range CatesianProductMap(m) {
+				np := *p
+				np.Children = map[string]*Property{}
+				for k, child := range mm {
+					child := child
+					np.Children[k] = &child
+				}
+				result = append(result, np)
+			}
+		case p.Variant != nil:
+			keys := make([]string, 0, len(p.Variant))
+			for k := range p.Variant {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				for _, variant := range monomorph(p.Variant[k]) {
+					variant := variant
+					np := *p
+					np.Variant = map[string]*Property{
+						k: &variant,
+					}
+					result = append(result, np)
+				}
+			}
+		default:
+			result = []Property{*p}
+		}
+		return result
+	}
+	return monomorph(prop)
+}

--- a/mockserver/swagger/monomorphisizer_test.go
+++ b/mockserver/swagger/monomorphisizer_test.go
@@ -1,0 +1,315 @@
+package swagger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonomorphization(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  Property
+		expect []Property
+	}{
+		{
+			name: "Basic",
+			input: Property{
+				addr: RootAddr,
+				Children: map[string]*Property{
+					"p1": {
+						addr: ParseAddr("p1"),
+					},
+				},
+			},
+			expect: []Property{
+				{
+					addr: RootAddr,
+					Children: map[string]*Property{
+						"p1": {
+							addr: ParseAddr("p1"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Polymorphic",
+			input: Property{
+				addr: RootAddr,
+				Variant: map[string]*Property{
+					"V1": {
+						addr: RootAddr,
+					},
+					"V2": {
+						addr: RootAddr,
+					},
+					"V3": {
+						addr: RootAddr,
+					},
+				},
+			},
+			expect: []Property{
+				{
+					addr: RootAddr,
+					Variant: map[string]*Property{
+						"V1": {
+							addr: RootAddr,
+						},
+					},
+				},
+				{
+					addr: RootAddr,
+					Variant: map[string]*Property{
+						"V2": {
+							addr: RootAddr,
+						},
+					},
+				},
+				{
+					addr: RootAddr,
+					Variant: map[string]*Property{
+						"V3": {
+							addr: RootAddr,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Object key is polymorphic",
+			input: Property{
+				addr: RootAddr,
+				Children: map[string]*Property{
+					"p1": {
+						addr: ParseAddr("p1"),
+						Variant: map[string]*Property{
+							"V1": {
+								addr: ParseAddr("p1"),
+							},
+							"V2": {
+								addr: ParseAddr("p1"),
+							},
+							"V3": {
+								addr: ParseAddr("p1"),
+							},
+						},
+					},
+				},
+			},
+			expect: []Property{
+				{
+					addr: RootAddr,
+					Children: map[string]*Property{
+						"p1": {
+							addr: ParseAddr("p1"),
+							Variant: map[string]*Property{
+								"V1": {
+									addr: ParseAddr("p1"),
+								},
+							},
+						},
+					},
+				},
+				{
+					addr: RootAddr,
+					Children: map[string]*Property{
+						"p1": {
+							addr: ParseAddr("p1"),
+							Variant: map[string]*Property{
+								"V2": {
+									addr: ParseAddr("p1"),
+								},
+							},
+						},
+					},
+				},
+				{
+					addr: RootAddr,
+					Children: map[string]*Property{
+						"p1": {
+							addr: ParseAddr("p1"),
+							Variant: map[string]*Property{
+								"V3": {
+									addr: ParseAddr("p1"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Element is polymorphic",
+			input: Property{
+				addr: RootAddr,
+				Element: &Property{
+					Variant: map[string]*Property{
+						"V1": {
+							addr: RootAddr,
+						},
+						"V2": {
+							addr: RootAddr,
+						},
+						"V3": {
+							addr: RootAddr,
+						},
+					},
+				},
+			},
+			expect: []Property{
+				{
+					addr: RootAddr,
+					Element: &Property{
+						Variant: map[string]*Property{
+							"V1": {
+								addr: RootAddr,
+							},
+						},
+					},
+				},
+				{
+					addr: RootAddr,
+					Element: &Property{
+						Variant: map[string]*Property{
+							"V2": {
+								addr: RootAddr,
+							},
+						},
+					},
+				},
+				{
+					addr: RootAddr,
+					Element: &Property{
+						Variant: map[string]*Property{
+							"V3": {
+								addr: RootAddr,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Mixed",
+			input: Property{
+				addr: RootAddr,
+				Children: map[string]*Property{
+					"p1": {
+						addr: ParseAddr("p1"),
+						Element: &Property{
+							addr: ParseAddr("p1.*"),
+							Variant: map[string]*Property{
+								"V1": {
+									addr: ParseAddr("p1.*"),
+									Children: map[string]*Property{
+										"pp1": {
+											addr: ParseAddr("p1.*.pp1"),
+										},
+									},
+								},
+								"V2": {
+									addr: ParseAddr("p1.*"),
+									Children: map[string]*Property{
+										"pp1": {
+											addr: ParseAddr("p1.*.pp1"),
+											Variant: map[string]*Property{
+												"W1": {
+													addr: ParseAddr("p1.*.pp1"),
+												},
+												"W2": {
+													addr: ParseAddr("p1.*.pp1"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: []Property{
+				{
+					addr: RootAddr,
+					Children: map[string]*Property{
+						"p1": {
+							addr: ParseAddr("p1"),
+							Element: &Property{
+								addr: ParseAddr("p1.*"),
+								Variant: map[string]*Property{
+									"V1": {
+										addr: ParseAddr("p1.*"),
+										Children: map[string]*Property{
+											"pp1": {
+												addr: ParseAddr("p1.*.pp1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					addr: RootAddr,
+					Children: map[string]*Property{
+						"p1": {
+							addr: ParseAddr("p1"),
+							Element: &Property{
+								addr: ParseAddr("p1.*"),
+								Variant: map[string]*Property{
+									"V2": {
+										addr: ParseAddr("p1.*"),
+										Children: map[string]*Property{
+											"pp1": {
+												addr: ParseAddr("p1.*.pp1"),
+												Variant: map[string]*Property{
+													"W1": {
+														addr: ParseAddr("p1.*.pp1"),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					addr: RootAddr,
+					Children: map[string]*Property{
+						"p1": {
+							addr: ParseAddr("p1"),
+							Element: &Property{
+								addr: ParseAddr("p1.*"),
+								Variant: map[string]*Property{
+									"V2": {
+										addr: ParseAddr("p1.*"),
+										Children: map[string]*Property{
+											"pp1": {
+												addr: ParseAddr("p1.*.pp1"),
+												Variant: map[string]*Property{
+													"W2": {
+														addr: ParseAddr("p1.*.pp1"),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expect, Monomorphization(&tt.input))
+		})
+	}
+}

--- a/mockserver/swagger/property.go
+++ b/mockserver/swagger/property.go
@@ -124,3 +124,27 @@ func (prop Property) Name() string {
 func (prop Property) String() string {
 	return prop.addr.String()
 }
+
+// IsMono tests whether the Property is monomorphisized
+func (prop *Property) IsMono() bool {
+	if prop == nil {
+		return true
+	}
+	if !prop.Element.IsMono() {
+		return false
+	}
+	for _, child := range prop.Children {
+		if !child.IsMono() {
+			return false
+		}
+	}
+	if len(prop.Variant) > 1 {
+		return false
+	}
+	for _, variant := range prop.Variant {
+		if !variant.IsMono() {
+			return false
+		}
+	}
+	return true
+}

--- a/mockserver/swagger/synth.go
+++ b/mockserver/swagger/synth.go
@@ -23,7 +23,10 @@ type SynthDuplicateElement struct {
 	Addr PropertyAddr
 }
 
-func NewSynthesizer(root *Property, rnd *Rnd, opt *SynthesizerOption) Synthesizer {
+func NewSynthesizer(root *Property, rnd *Rnd, opt *SynthesizerOption) (*Synthesizer, error) {
+	if !root.IsMono() {
+		return nil, fmt.Errorf("property is not monomorphisized")
+	}
 	if opt == nil {
 		opt = &SynthesizerOption{}
 	}
@@ -31,18 +34,17 @@ func NewSynthesizer(root *Property, rnd *Rnd, opt *SynthesizerOption) Synthesize
 	for _, de := range opt.DuplicateElements {
 		dem[de.Addr.String()] = de.Cnt
 	}
-	return Synthesizer{
+	return &Synthesizer{
 		root:              root,
 		rnd:               rnd,
 		useEnumValues:     opt.UseEnumValues,
 		duplicateElements: dem,
-	}
+	}, nil
 }
 
-func (syn *Synthesizer) Synthesize() []interface{} {
-	var synProp func(parent, p *Property) []interface{}
-	synProp = func(parent, p *Property) []interface{} {
-		var result []interface{}
+func (syn *Synthesizer) Synthesize() interface{} {
+	var synProp func(parent, p *Property) interface{}
+	synProp = func(parent, p *Property) interface{} {
 		switch {
 		case p.Element != nil:
 			n := 1
@@ -50,66 +52,51 @@ func (syn *Synthesizer) Synthesize() []interface{} {
 				n += cnt
 			}
 
-			var innerMatrix [][]interface{}
+			var elements []interface{}
 			for i := 0; i < n; i++ {
-				inners := synProp(p, p.Element)
-				innerMatrix = append(innerMatrix, inners)
+				inner := synProp(p, p.Element)
+				elements = append(elements, inner)
 			}
 
 			if SchemaIsArray(p.Schema) {
-				for i := 0; i < len(innerMatrix[0]); i++ {
-					var res []interface{}
-					for j := 0; j < n; j++ {
-						inner := innerMatrix[j][i]
-						res = append(res, inner)
-					}
-					result = append(result, res)
-				}
+				return elements
 			} else {
 				// map
-				for i := 0; i < len(innerMatrix[0]); i++ {
-					res := map[string]interface{}{}
-					for j := 0; j < n; j++ {
-						key := "KEY"
-						if j != 0 {
-							key = fmt.Sprintf("KEY%d", j)
-						}
-						inner := innerMatrix[j][i]
-						res[key] = inner
+				res := map[string]interface{}{}
+				for i := 0; i < n; i++ {
+					key := "KEY"
+					if i != 0 {
+						key = fmt.Sprintf("KEY%d", i)
 					}
-					result = append(result, res)
+					inner := elements[i]
+					res[key] = inner
 				}
+				return res
 			}
 		case p.Children != nil:
-			m := map[string][]interface{}{}
 			// empty object
 			if len(p.Children) == 0 {
-				result = append(result, map[string]interface{}{})
+				return map[string]interface{}{}
 			} else {
+				res := map[string]interface{}{}
 				keys := make([]string, 0, len(p.Children))
 				for k := range p.Children {
 					keys = append(keys, k)
 				}
 				sort.Strings(keys)
 				for _, k := range keys {
-					m[k] = synProp(p, p.Children[k])
+					res[k] = synProp(p, p.Children[k])
 				}
-				for _, v := range CatesianProductMap(m) {
-					result = append(result, v)
-				}
+				return res
 			}
 		case p.Variant != nil:
-			keys := make([]string, 0, len(p.Variant))
-			for k := range p.Variant {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-			for _, k := range keys {
-				result = append(result, synProp(p, p.Variant[k])...)
+			for _, v := range p.Variant {
+				// There must be at most one variant
+				return synProp(p, v)
 			}
 		default:
 			if p.Schema == nil {
-				return result
+				return nil
 			}
 			if len(p.Schema.Type) != 1 {
 				panic(fmt.Sprintf("%s: schema type as array is not supported", *p))
@@ -118,93 +105,31 @@ func (syn *Synthesizer) Synthesize() []interface{} {
 			case "string":
 				if parent != nil && parent.Discriminator != "" && parent.Discriminator == p.Name() {
 					// discriminator property
-					result = []interface{}{parent.DiscriminatorValue}
+					return parent.DiscriminatorValue
 				} else {
 					// regular string
 					if syn.useEnumValues && len(p.Schema.Enum) != 0 {
-						result = []interface{}{p.Schema.Enum[0].(string)}
+						return p.Schema.Enum[0].(string)
 					} else {
-						result = []interface{}{syn.rnd.NextString(p.Schema.Format)}
+						return syn.rnd.NextString(p.Schema.Format)
 					}
 				}
 			case "file":
-				result = []interface{}{syn.rnd.NextString(p.Schema.Format)}
+				return syn.rnd.NextString(p.Schema.Format)
 			case "integer":
-				result = []interface{}{syn.rnd.NextInteger(p.Schema.Format)}
+				return syn.rnd.NextInteger(p.Schema.Format)
 			case "number":
-				result = []interface{}{syn.rnd.NextNumber(p.Schema.Format)}
+				return syn.rnd.NextNumber(p.Schema.Format)
 			case "boolean":
-				result = []interface{}{true}
+				return false
 			case "object", "", "array":
 				// Returns nothing as this implies there is a circular ref hit
 			default:
 				panic(fmt.Sprintf("%s: unknown schema type %s", *p, t))
 			}
 		}
-		return result
+		panic("unreachable")
 	}
 
 	return synProp(nil, syn.root)
-}
-
-func CatesianProduct[T any](params ...[]T) [][]T {
-	if params == nil {
-		return nil
-	}
-	result := [][]T{}
-	for _, param := range params {
-		if len(param) != 0 {
-			newresult := [][]T{}
-			for _, v := range param {
-				if len(result) == 0 {
-					res := []T{v}
-					newresult = append(newresult, res)
-				} else {
-					for _, res := range result {
-						nres := make([]T, len(res))
-						copy(nres, res)
-						nres = append(nres, v)
-						newresult = append(newresult, nres)
-					}
-				}
-			}
-			result = newresult
-		}
-	}
-	return result
-}
-
-func CatesianProductMap[T any](params map[string][]T) []map[string]T {
-	if params == nil {
-		return nil
-	}
-	result := []map[string]T{}
-	keys := make([]string, 0, len(params))
-	for k := range params {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		param := params[k]
-		if len(param) != 0 {
-			newresult := []map[string]T{}
-			for _, v := range param {
-				if len(result) == 0 {
-					res := map[string]T{k: v}
-					newresult = append(newresult, res)
-				} else {
-					for _, res := range result {
-						nres := map[string]T{}
-						for kk, vv := range res {
-							nres[kk] = vv
-						}
-						nres[k] = v
-						newresult = append(newresult, nres)
-					}
-				}
-			}
-			result = newresult
-		}
-	}
-	return result
 }

--- a/mockserver/swagger/synth_test.go
+++ b/mockserver/swagger/synth_test.go
@@ -10,126 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCatesianProduct(t *testing.T) {
-	cases := []struct {
-		name   string
-		params [][]interface{}
-		expect [][]interface{}
-	}{
-		{
-			name:   "nil",
-			params: nil,
-			expect: nil,
-		},
-		{
-			name:   "empty",
-			params: [][]interface{}{},
-			expect: [][]interface{}{},
-		},
-		{
-			name:   "[1]",
-			params: [][]interface{}{{1}},
-			expect: [][]interface{}{{1}},
-		},
-		{
-			name:   "[1, 2]",
-			params: [][]interface{}{{1, 2}},
-			expect: [][]interface{}{{1}, {2}},
-		},
-		{
-			name:   "[1, 2] x [3]",
-			params: [][]interface{}{{1, 2}, {3}},
-			expect: [][]interface{}{{1, 3}, {2, 3}},
-		},
-		{
-			name:   "[1] x []",
-			params: [][]interface{}{{1}, {}},
-			expect: [][]interface{}{{1}},
-		},
-		{
-			name:   "[1, 2] x [3, 4] x [5, 6]",
-			params: [][]interface{}{{1, 2}, {3, 4}, {5, 6}},
-			expect: [][]interface{}{
-				{1, 3, 5},
-				{2, 3, 5},
-				{1, 4, 5},
-				{2, 4, 5},
-				{1, 3, 6},
-				{2, 3, 6},
-				{1, 4, 6},
-				{2, 4, 6},
-			},
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expect, CatesianProduct(tt.params...))
-		})
-	}
-}
-
-func TestCatesianProductMap(t *testing.T) {
-	cases := []struct {
-		name   string
-		params map[string][]interface{}
-		expect []map[string]interface{}
-	}{
-		{
-			name:   "nil",
-			params: nil,
-			expect: nil,
-		},
-		{
-			name:   "empty",
-			params: map[string][]interface{}{},
-			expect: []map[string]interface{}{},
-		},
-		{
-			name:   "{a: []}",
-			params: map[string][]interface{}{"a": {}},
-			expect: []map[string]interface{}{},
-		},
-		{
-			name:   "{a: [1]}",
-			params: map[string][]interface{}{"a": {1}},
-			expect: []map[string]interface{}{{"a": 1}},
-		},
-		{
-			name:   "{a: [1, 2]}",
-			params: map[string][]interface{}{"a": {1, 2}},
-			expect: []map[string]interface{}{{"a": 1}, {"a": 2}},
-		},
-		{
-			name:   "{a: [1], b: []}",
-			params: map[string][]interface{}{"a": {1}, "b": {}},
-			expect: []map[string]interface{}{{"a": 1}},
-		},
-		{
-			name:   "{a: [1, 2]} x {b: [3]}",
-			params: map[string][]interface{}{"a": {1, 2}, "b": {3}},
-			expect: []map[string]interface{}{{"a": 1, "b": 3}, {"a": 2, "b": 3}},
-		},
-		{
-			name:   "{a: [1, 2]} x {b: [3]} x {c: [40, 50]}",
-			params: map[string][]interface{}{"a": {1, 2}, "b": {3}, "c": {40, 50}},
-			expect: []map[string]interface{}{
-				{"a": 1, "b": 3, "c": 40},
-				{"a": 2, "b": 3, "c": 40},
-				{"a": 1, "b": 3, "c": 50},
-				{"a": 2, "b": 3, "c": 50},
-			},
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			result := CatesianProductMap(tt.params)
-			require.Equal(t, tt.expect, result)
-		})
-	}
-}
-
 func TestSynthesize(t *testing.T) {
 	pwd, err := os.Getwd()
 	require.NoError(t, err)
@@ -150,7 +30,7 @@ func TestSynthesize(t *testing.T) {
 		  "array": [
 		    "b"
 		  ],
-		  "boolean": true,
+		  "boolean": false,
 		  "emptyObject": {},
 		  "integer": 1,
 		  "map": {
@@ -193,7 +73,7 @@ func TestSynthesize(t *testing.T) {
 		    "b",
 			"c"
 		  ],
-		  "boolean": true,
+		  "boolean": false,
 		  "emptyObject": {},
 		  "integer": 1,
 		  "map": {
@@ -229,7 +109,7 @@ func TestSynthesize(t *testing.T) {
 				`
 		{
 			"type": "var2",
-			"prop2": "c"
+			"prop2": "b"
 		}
 						`,
 			},
@@ -296,7 +176,7 @@ func TestSynthesize(t *testing.T) {
 		{
 			"prop": {
 				"type": "var2",
-				"prop2": "c"
+				"prop2": "b"
 			}
 		}
 						`,
@@ -321,7 +201,7 @@ func TestSynthesize(t *testing.T) {
 			{
 				"prop": {
 					"type": "var2",
-					"prop2": "c"
+					"prop2": "b"
 				}
 			}
 		]
@@ -351,7 +231,7 @@ func TestSynthesize(t *testing.T) {
 			{
 				"prop": {
 					"type": "var1",
-					"prop1": "d"
+					"prop1": "c"
 				}
 			}
 		]
@@ -361,13 +241,13 @@ func TestSynthesize(t *testing.T) {
 			{
 				"prop": {
 					"type": "var2",
-					"prop2": "c"
+					"prop2": "b"
 				}
 			},
 			{
 				"prop": {
 					"type": "var2",
-					"prop2": "e"
+					"prop2": "c"
 				}
 			}
 		]
@@ -404,14 +284,14 @@ func TestSynthesize(t *testing.T) {
 	"type": "L1Var1",
 	"p11": {
 		"type": "L2Var2",
-		"p22": "c"
+		"p22": "b"
 	}
 }
 				`,
 				`
 {
 	"type": "L1Var2",
-	"p12": "d"
+	"p12": "b"
 }
 				`,
 			},
@@ -440,10 +320,13 @@ func TestSynthesize(t *testing.T) {
 			exp, err := NewExpander(ref, nil)
 			require.NoError(t, err)
 			require.NoError(t, exp.Expand())
-			syn := NewSynthesizer(exp.Root(), ptr(NewRnd(nil)), tt.opt)
-			results := syn.Synthesize()
-			require.Len(t, results, len(tt.expect))
-			for i, res := range results {
+			propInstances := Monomorphization(exp.Root())
+			require.Len(t, propInstances, len(tt.expect))
+			for i, v := range propInstances {
+				propInstance := v
+				syn, err := NewSynthesizer(&propInstance, ptr(NewRnd(nil)), tt.opt)
+				require.NoError(t, err)
+				res := syn.Synthesize()
 				b, err := json.Marshal(res)
 				require.NoError(t, err)
 				require.JSONEq(t, tt.expect[i], string(b))


### PR DESCRIPTION
Extract synth to be monomorphization + synth, this is to prepare the support of boolean auto-detection in the future.

Monomorphization is used to convert a model descriptor into a deterministic list of instantiated model descriptors (or mono model), which means the latter ones have no multi-variants.

The synth is then use each of these mono model to fill in the values. The duplicating array functionality still resides in the synth step.