### PR TITLE
`execution` block introduces new `vibrate` block

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,6 @@ Each `execution` block is defined below:
 
 ```hcl
 execution "name" "type" {
-    # 0 or more override blocks, that only applies to this execution
-    override {
-        #...
-    }
-
     # additional environment variables for this execution
     env = {
         #...
@@ -151,6 +146,16 @@ execution "name" "type" {
     args = [
         #...
     ]
+
+    # 0 or more override blocks, that only applies to this execution
+    override {
+        #...
+    }
+
+    # 0 or more vibrate blocks, that only applies to this execution
+    vibrate {
+        #...
+    }
 }
 ```
 
@@ -216,6 +221,18 @@ Each `duplicate_element` block is defined below:
 duplicate_element {
     count = 1       # (Optional) The count of duplications. By default, 1.
     addr  = "..."   # The address to the property to duplicate, see `PropertyAddr` for the correct format
+}
+```
+
+---
+
+Each `vibrate` block is defined below:
+
+```hcl
+vibrate {
+    path_pattern = "..." # regexp of the API path pattern, if it is matched against the request sent to the mock server, it will modify the response per the settings defined in this block
+    path = "..."         # The JSON pointer references an *leaf* location within the response (after override), who is of a primary type
+    value = "..."        # The value to be applied to above path, which should be different than its original value (the override response)
 }
 ```
 

--- a/ctrl/config.go
+++ b/ctrl/config.go
@@ -17,6 +17,12 @@ type Override struct {
 	SynthOption           *SynthOption      `hcl:"synthesizer,block"`
 }
 
+type Vibrate struct {
+	PathPattern string      `hcl:"path_pattern,attr"`
+	Path        string      `hcl:"path,attr"`
+	Value       interface{} `hcl:"value,attr"`
+}
+
 type Execution struct {
 	Name string `hcl:"name,label"`
 	Type string `hcl:"type,label"`
@@ -24,6 +30,7 @@ type Execution struct {
 	Skip       bool              `hcl:"skip,optional"`
 	SkipReason string            `hcl:"skip_reason,optional"`
 	Overrides  []Override        `hcl:"override,block"`
+	Vibrate    []Vibrate         `hcl:"vibrate,block"`
 	Env        map[string]string `hcl:"env,optional"`
 	Dir        string            `hcl:"dir,optional"`
 	Path       string            `hcl:"path,attr"`

--- a/ctrl/config.go
+++ b/ctrl/config.go
@@ -1,5 +1,7 @@
 package ctrl
 
+import "github.com/zclconf/go-cty/cty"
+
 type Config struct {
 	Overrides  []Override  `hcl:"override,block"`
 	Executions []Execution `hcl:"execution,block"`
@@ -17,10 +19,10 @@ type Override struct {
 	SynthOption           *SynthOption      `hcl:"synthesizer,block"`
 }
 
-type Vibrate struct {
-	PathPattern string      `hcl:"path_pattern,attr"`
-	Path        string      `hcl:"path,attr"`
-	Value       interface{} `hcl:"value,attr"`
+type Vibration struct {
+	PathPattern string    `hcl:"path_pattern,attr"`
+	Path        string    `hcl:"path,attr"`
+	Value       cty.Value `hcl:"value,attr"`
 }
 
 type Execution struct {
@@ -30,7 +32,7 @@ type Execution struct {
 	Skip       bool              `hcl:"skip,optional"`
 	SkipReason string            `hcl:"skip_reason,optional"`
 	Overrides  []Override        `hcl:"override,block"`
-	Vibrate    []Vibrate         `hcl:"vibrate,block"`
+	Vibrate    []Vibration       `hcl:"vibrate,block"`
 	Env        map[string]string `hcl:"env,optional"`
 	Dir        string            `hcl:"dir,optional"`
 	Path       string            `hcl:"path,attr"`

--- a/ctrl/ctrl.go
+++ b/ctrl/ctrl.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -37,6 +38,8 @@ type Ctrl struct {
 	ExecFrom  string
 	ExecTo    string
 	execState ExecutionState
+
+	expanderCache *swagger.ExpanderCache
 }
 
 type ExecutionState int
@@ -88,6 +91,7 @@ func NewCtrl(opt Option) (*Ctrl, error) {
 		ExecFrom:      opt.ExecFrom,
 		ExecTo:        opt.ExecTo,
 		execState:     ExecutionStateBeforeRun,
+		expanderCache: swagger.NewExpanderCache(),
 	}, nil
 }
 
@@ -153,8 +157,6 @@ func (ctrl *Ctrl) Run(ctx context.Context) error {
 	execSucceed := 0
 	execFail := 0
 
-	expCache := swagger.NewExpanderCache()
-
 	// Launch each execution
 	for i, execution := range ctrl.ExecSpec.Executions {
 		switch ctrl.execState {
@@ -185,112 +187,8 @@ func (ctrl *Ctrl) Run(ctx context.Context) error {
 			continue
 		}
 
-		run := func(execution Execution) error {
-
-			overrides := append([]Override{}, execution.Overrides...)
-			overrides = append(overrides, ctrl.ExecSpec.Overrides...)
-
-			var ovs []mockserver.Override
-			for _, override := range overrides {
-				ov := mockserver.Override{
-					PathPattern:           *regexp.MustCompile(override.PathPattern),
-					ResponseSelectorMerge: override.ResponseSelectorMerge,
-					ResponseSelectorJSON:  override.ResponseSelectorJSON,
-					ResponseBody:          override.ResponseBody,
-					ResponsePatchMerge:    override.ResponsePatchMerge,
-					ResponsePatchJSON:     override.ResponsePatchJSON,
-					ResponseHeader:        override.ResponseHeader,
-					SynthOption:           &swagger.SynthesizerOption{},
-					ExpanderOption: &swagger.ExpanderOption{
-						Cache: expCache,
-					},
-				}
-				if opt := override.SynthOption; opt != nil {
-					if opt.UseEnumValue {
-						ov.SynthOption.UseEnumValues = true
-					}
-					var del []swagger.SynthDuplicateElement
-					for _, eopt := range opt.DuplicateElement {
-						cnt := 1
-						if eopt.Count != nil {
-							cnt = *eopt.Count
-						}
-						del = append(del, swagger.SynthDuplicateElement{
-							Cnt:  cnt,
-							Addr: swagger.ParseAddr(eopt.Addr),
-						})
-					}
-					ov.SynthOption.DuplicateElements = del
-				}
-				if opt := override.ExpanderOption; opt != nil {
-					if opt.EmptyObjAsStr {
-						ov.ExpanderOption.EmptyObjAsStr = true
-					}
-					if opt.DisableCache {
-						ov.ExpanderOption.Cache = nil
-					}
-				}
-
-				ovs = append(ovs, ov)
-			}
-
-			ctrl.MockServer.InitExecution(ovs)
-
-			env := os.Environ()
-			for k, v := range execution.Env {
-				env = append(env, k+"="+v)
-			}
-
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-
-			cmd := exec.Cmd{
-				Path:   execution.Path,
-				Args:   append([]string{filepath.Base(execution.Path)}, execution.Args...),
-				Env:    env,
-				Dir:    execution.Dir,
-				Stdout: &stdout,
-				Stderr: &stderr,
-			}
-
-			log.Info(fmt.Sprintf("Executing %s (%d/%d)", execution, i+1, execTotal))
-
-			log.Debug("execution detail", "path", execution.Path, "args", execution.Args, "env", env, "dir", execution.Dir)
-
-			if err := cmd.Run(); err != nil {
-				log.Error("run failure", "stdout", stdout.String(), "stderr", stderr.String())
-				return fmt.Errorf("running execution %q: %v", execution, err)
-			}
-
-			log.Debug("execution result", "stdout", stdout.String())
-
-			var appModel interface{}
-			if err := json.Unmarshal(stdout.Bytes(), &appModel); err != nil {
-				log.Error("post-execution unmarshal failure", "error", err, "stdout", stdout.String())
-				return fmt.Errorf("post-execution %q unmarshal: %v", execution, err)
-			}
-
-			m, err := MapSingleAppModel(appModel, ctrl.MockServer.Records()...)
-			if err != nil {
-				log.Error("post-execution map models", "error", err)
-				return fmt.Errorf("post-execution %q map models: %v", execution, err)
-			}
-
-			if err := m.AddLink(ctrl.MockServer.Idx.Commit, ctrl.MockServer.Specdir); err != nil {
-				log.Error("post-execution model map adding link", "error", err)
-				return fmt.Errorf("post-execution model map adding link: %v", err)
-			}
-			if err := m.RelativeLocalLink(ctrl.MockServer.Specdir); err != nil {
-				log.Error("post-execution model map relative local link", "error", err)
-				return fmt.Errorf("post-execution model map relative local link: %v", err)
-			}
-
-			results[execution.Name] = append(results[execution.Name], m)
-
-			return nil
-		}
-
-		if err := run(execution); err != nil {
+		m, err := ctrl.execute(ctx, execution, i, execTotal)
+		if err != nil {
 			execFail++
 			if ctrl.ContinueOnErr {
 				continue
@@ -298,6 +196,7 @@ func (ctrl *Ctrl) Run(ctx context.Context) error {
 			return err
 		} else {
 			execSucceed++
+			results[execution.Name] = append(results[execution.Name], *m)
 		}
 	}
 
@@ -336,4 +235,215 @@ func (ctrl *Ctrl) WriteResult(ctx context.Context, results map[string][]SingleMo
 
 	fmt.Println(string(b))
 	return nil
+}
+
+func (ctrl *Ctrl) execute(ctx context.Context, execution Execution, execIdx, execTotal int) (*SingleModelMap, error) {
+	overrides := append([]Override{}, execution.Overrides...)
+	overrides = append(overrides, ctrl.ExecSpec.Overrides...)
+
+	var ovs []mockserver.Override
+	for _, override := range overrides {
+		ov := mockserver.Override{
+			PathPattern:           *regexp.MustCompile(override.PathPattern),
+			ResponseSelectorMerge: override.ResponseSelectorMerge,
+			ResponseSelectorJSON:  override.ResponseSelectorJSON,
+			ResponseBody:          override.ResponseBody,
+			ResponsePatchMerge:    override.ResponsePatchMerge,
+			ResponsePatchJSON:     override.ResponsePatchJSON,
+			ResponseHeader:        override.ResponseHeader,
+			SynthOption:           &swagger.SynthesizerOption{},
+			ExpanderOption: &swagger.ExpanderOption{
+				Cache: ctrl.expanderCache,
+			},
+		}
+		if opt := override.SynthOption; opt != nil {
+			if opt.UseEnumValue {
+				ov.SynthOption.UseEnumValues = true
+			}
+			var del []swagger.SynthDuplicateElement
+			for _, eopt := range opt.DuplicateElement {
+				cnt := 1
+				if eopt.Count != nil {
+					cnt = *eopt.Count
+				}
+				del = append(del, swagger.SynthDuplicateElement{
+					Cnt:  cnt,
+					Addr: swagger.ParseAddr(eopt.Addr),
+				})
+			}
+			ov.SynthOption.DuplicateElements = del
+		}
+		if opt := override.ExpanderOption; opt != nil {
+			if opt.EmptyObjAsStr {
+				ov.ExpanderOption.EmptyObjAsStr = true
+			}
+			if opt.DisableCache {
+				ov.ExpanderOption.Cache = nil
+			}
+		}
+
+		ovs = append(ovs, ov)
+	}
+
+	ctrl.MockServer.InitExecution(ovs)
+
+	appModel, err := ctrl.runCommand(ctx, execution, execIdx, execTotal, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := MapSingleAppModel(appModel, ctrl.MockServer.Records()...)
+	if err != nil {
+		log.Error("post-execution map models", "error", err)
+		return nil, fmt.Errorf("post-execution %q map models: %v", execution, err)
+	}
+
+	base := BaseExecInfo{
+		appJSON: appModel,
+		seq:     ctrl.MockServer.Sequences(),
+	}
+
+	for i, vibrate := range execution.Vibrate {
+		mm, err := ctrl.vibrate(ctx, execution, vibrate, base, execIdx, execTotal, i, len(execution.Vibrate))
+		if err != nil {
+			log.Error("post-execution vibration execution", "error", err)
+			return nil, fmt.Errorf("post-execution vibration execution: %v", err)
+		}
+		for k, v := range mm {
+			if _, ok := m[k]; !ok {
+				m[k] = v
+			} else {
+				log.Warn("The %d-th vibration is redundent", i)
+			}
+		}
+	}
+
+	if err := m.AddLink(ctrl.MockServer.Idx.Commit, ctrl.MockServer.Specdir); err != nil {
+		log.Error("post-execution model map adding link", "error", err)
+		return nil, fmt.Errorf("post-execution model map adding link: %v", err)
+	}
+	if err := m.RelativeLocalLink(ctrl.MockServer.Specdir); err != nil {
+		log.Error("post-execution model map relative local link", "error", err)
+		return nil, fmt.Errorf("post-execution model map relative local link: %v", err)
+	}
+
+	return &m, nil
+}
+
+func (ctrl *Ctrl) runCommand(ctx context.Context, execution Execution, execIdx, execTotal int, vibrateIdx, vibrateTotal int) (map[string]interface{}, error) {
+	env := os.Environ()
+	for k, v := range execution.Env {
+		env = append(env, k+"="+v)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd := exec.Cmd{
+		Path:   execution.Path,
+		Args:   append([]string{filepath.Base(execution.Path)}, execution.Args...),
+		Env:    env,
+		Dir:    execution.Dir,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	vibrateMsg := func(vibrateIdx, vibrateTotal int) string {
+		if vibrateTotal == 0 {
+			return ""
+		}
+		return fmt.Sprintf(" by vibrating (%d/%d)", vibrateIdx+1, vibrateTotal)
+	}
+
+	log.Info(fmt.Sprintf("Executing %s (%d/%d)%s", execution, execIdx+1, execTotal, vibrateMsg(vibrateIdx, vibrateTotal)))
+
+	if vibrateTotal == 0 {
+		log.Debug("execution detail", "path", execution.Path, "args", execution.Args, "env", env, "dir", execution.Dir)
+	}
+
+	if err := cmd.Run(); err != nil {
+		log.Error("run failure", "stdout", stdout.String(), "stderr", stderr.String())
+		return nil, fmt.Errorf("running execution %q%s: %v", execution, vibrateMsg(vibrateIdx, vibrateTotal), err)
+	}
+
+	log.Debug("execution result", "stdout", stdout.String())
+
+	var appModel map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &appModel); err != nil {
+		log.Error(fmt.Sprintf("post-execution%s unmarshal failure", vibrateMsg(vibrateIdx, vibrateTotal)), "error", err, "stdout", stdout.String())
+		return nil, fmt.Errorf("post-execution %q%s unmarshal: %v", execution, vibrateMsg(vibrateIdx, vibrateTotal), err)
+	}
+
+	return appModel, nil
+}
+
+type BaseExecInfo struct {
+	appJSON map[string]interface{}
+	seq     []mockserver.MonoModelDesc
+}
+
+// vibrate runs a vibration execution and compares it with the base execution and returns a model mapping.
+func (ctrl *Ctrl) vibrate(ctx context.Context, execution Execution, vibrate Vibrate, base BaseExecInfo, execIdx, execTotal int, vibrateIdx, vibrateTotal int) (SingleModelMap, error) {
+	ctrl.MockServer.InitVibrate(&mockserver.Vibration{
+		PathPattern: *regexp.MustCompile(vibrate.PathPattern),
+		Path:        vibrate.Path,
+		Value:       vibrate.Value,
+	})
+
+	vibrateAppModel, err := ctrl.runCommand(ctx, execution, execIdx, execTotal, vibrateIdx, vibrateTotal)
+	if err != nil {
+		return nil, err
+	}
+
+	nSeq := ctrl.MockServer.Sequences()
+	if !slices.Equal(base.seq, nSeq) {
+		log.Error("API invocation sequence not matched", "vibration_idx", vibrateIdx, "old", base.seq, "new", nSeq)
+		return nil, fmt.Errorf("API invocation sequence not matched between the basic execution and the %d-th vibrated execution", vibrateIdx)
+	}
+
+	fltAppModel := flattenJSON(base.appJSON)
+	fltVibrateAppModel := flattenJSON(vibrateAppModel)
+	l1, l2, ldiff := compareFlattendJSON(fltAppModel, fltVibrateAppModel)
+	if len(l1)+len(l2)+len(ldiff) == 0 {
+		log.Warn("Vibration causes no diff vs base model")
+		return nil, nil
+	}
+	if len(l1)+len(l2) != 0 {
+		msg := "Vibration causes "
+		if len(l1) != 0 {
+			msg += fmt.Sprintf("properties only in base model: %v", l1)
+		}
+		if len(l2) != 0 {
+			if len(l1) != 0 {
+				msg += " and "
+			}
+			msg += fmt.Sprintf("properties only in vibration model: %v", l2)
+		}
+		log.Error("Vibration causes property set mismatch", "base only props", l1, "vibration only props", l2)
+		return nil, fmt.Errorf(msg)
+	}
+	if len(ldiff) != 1 {
+		log.Warn("Vibration causes more than one diff properties", "properties", ldiff)
+		// TODO: conditionally accept this
+		return nil, nil
+	}
+	appPropAddr := ldiff[0]
+
+	vibrationRecord := ctrl.MockServer.VibrationRecord()
+	if vibrationRecord == nil {
+		log.Error("vibration record is unexpected nil")
+		return nil, fmt.Errorf("vibration record is unexpected nil")
+	}
+	fltAPIModel := swagger.FlattenJSONValueObjectByAddr((*vibrationRecord).(swagger.JSONObject))
+	for k, v := range fltAPIModel {
+		ptr, err := swagger.ParseAddr(k).ToPointer()
+		if err != nil {
+			return nil, err
+		}
+		if ptr.String() != vibrate.Path {
+			continue
+		}
+		return SingleModelMap{appPropAddr: v.JSONValuePos()}, nil
+	}
+	return nil, fmt.Errorf("failed to find a leaf property address %s in the vibration model", vibrate.Path)
 }

--- a/ctrl/map.go
+++ b/ctrl/map.go
@@ -20,76 +20,6 @@ import (
 // encountered a circular reference during its expansion, the value of the map is nil.
 type SingleModelMap map[string]*swagger.JSONValuePos
 
-// AddLink adds the LinkLocal and LinkGithuhub for each value (*swagger.JSONValuePos) of the SignleModelMap.
-func (m SingleModelMap) AddLink(commit, specdir string) error {
-	pm := map[string][]jsonpointer.Pointer{}
-	for k, v := range m {
-		if v == nil {
-			// We deliberately not nil checking `jsonpos` here, as the response is generated with the guarantee that no circular/undefined property will be generated.
-			// In other words, the jsonpos here must be non-nil. Otherwise, it indicates a bug in the code.
-			return fmt.Errorf("unexpected nil JSONValuePos got for %s, this is either a code bug or user usage error", k)
-		}
-		filepath := v.Ref.GetURL().Path
-		pm[filepath] = append(pm[filepath], *v.Ref.GetPointer())
-	}
-	posm := map[string]map[string]jsonpointerpos.JSONPointerPosition{}
-	for fpath, ptrs := range pm {
-		b, err := os.ReadFile(fpath)
-		if err != nil {
-			return fmt.Errorf("reading %s: %v", fpath, err)
-		}
-		posResult, err := jsonpointerpos.GetPositions(string(b), ptrs)
-		if err != nil {
-			return err
-		}
-		posm[fpath] = posResult
-	}
-	for _, v := range m {
-		fpath := v.Ref.GetURL().Path
-		relFile, err := filepath.Rel(specdir, fpath)
-		if err != nil {
-			return err
-		}
-		pos, ok := posm[fpath][v.Ref.GetPointer().String()]
-		if !ok {
-			return fmt.Errorf("can't find file position for %s", &v.Ref)
-		}
-		v.LinkLocal = fmt.Sprintf("%s:%d:%d", fpath, pos.Line, pos.Column)
-		if commit != "" {
-			v.LinkGithub = "https://github.com/Azure/azure-rest-api-specs/blob/" + commit + "/specification/" + relFile + "#L" + strconv.Itoa(pos.Line)
-		}
-	}
-	return nil
-}
-
-func (m SingleModelMap) RelativeLocalLink(specdir string) error {
-	for _, pos := range m {
-		if pos.Ref.GetURL() != nil {
-			path, err := filepath.Rel(specdir, pos.Ref.GetURL().Path)
-			if err != nil {
-				return err
-			}
-			pos.Ref = jsonreference.MustCreateRef(path + "#" + pos.Ref.GetPointer().String())
-		}
-		if pos.LinkLocal != "" {
-			parts := strings.SplitN(pos.LinkLocal, ":", 2)
-			path, err := filepath.Rel(specdir, parts[0])
-			if err != nil {
-				return err
-			}
-			pos.LinkLocal = path + ":" + parts[1]
-		}
-		if ref := pos.RootModel.PathRef; ref.GetURL() != nil {
-			path, err := filepath.Rel(specdir, ref.GetURL().Path)
-			if err != nil {
-				return err
-			}
-			pos.RootModel.PathRef = jsonreference.MustCreateRef(path + "#" + ref.GetPointer().String())
-		}
-	}
-	return nil
-}
-
 func MapSingleAppModel(appModel map[string]interface{}, apiModels ...swagger.JSONValue) (SingleModelMap, error) {
 	apiValueMap, err := swagger.JSONValueValueMap(apiModels...)
 	if err != nil {
@@ -107,23 +37,36 @@ func MapSingleAppModel(appModel map[string]interface{}, apiModels ...swagger.JSO
 	return m, nil
 }
 
+func (smm SingleModelMap) ToModelMap() ModelMap {
+	m := ModelMap{}
+	for k, v := range smm {
+		m[k] = []*swagger.JSONValuePos{v}
+	}
+	return m
+}
+
 // ModelMap is same as SingleModelMap, but might maps one app model property to multiple API model properties.
 // This is resulted from merging multiple SingleModelMap(s).
 type ModelMap map[string][]*swagger.JSONValuePos
 
-func NewModelMap(models []SingleModelMap) ModelMap {
+func (mm ModelMap) Add(omm ModelMap) ModelMap {
 	tmpM := map[string]map[string]*swagger.JSONValuePos{}
-	for _, model := range models {
-		for k, v := range model {
+	for k, poses := range mm {
+		for _, pos := range poses {
+			tmpM[k] = map[string]*swagger.JSONValuePos{pos.String(): pos}
+		}
+	}
+	for k, poses := range omm {
+		for _, pos := range poses {
 			m, ok := tmpM[k]
 			if !ok {
 				m = map[string]*swagger.JSONValuePos{}
 				tmpM[k] = m
 			}
-			// We use API property address as the unique key
-			m[v.Addr.String()] = v
+			m[pos.String()] = pos
 		}
 	}
+
 	result := ModelMap{}
 	for k, m := range tmpM {
 		var l []*swagger.JSONValuePos
@@ -136,6 +79,82 @@ func NewModelMap(models []SingleModelMap) ModelMap {
 		result[k] = l
 	}
 	return result
+}
+
+// AddLink adds the LinkLocal and LinkGithuhub for each value (*swagger.JSONValuePos) of the ModelMap.
+func (m ModelMap) AddLink(commit, specdir string) error {
+	pm := map[string][]jsonpointer.Pointer{}
+	for k, poses := range m {
+		for _, pos := range poses {
+			if pos == nil {
+				// We deliberately not nil checking `jsonpos` here, as the response is generated with the guarantee that no circular/undefined property will be generated.
+				// In other words, the jsonpos here must be non-nil. Otherwise, it indicates a bug in the code.
+				return fmt.Errorf("unexpected nil JSONValuePos got for %s, this is either a code bug or user usage error", k)
+			}
+			filepath := pos.Ref.GetURL().Path
+			pm[filepath] = append(pm[filepath], *pos.Ref.GetPointer())
+		}
+	}
+	posm := map[string]map[string]jsonpointerpos.JSONPointerPosition{}
+	for fpath, ptrs := range pm {
+		b, err := os.ReadFile(fpath)
+		if err != nil {
+			return fmt.Errorf("reading %s: %v", fpath, err)
+		}
+		posResult, err := jsonpointerpos.GetPositions(string(b), ptrs)
+		if err != nil {
+			return err
+		}
+		posm[fpath] = posResult
+	}
+	for _, poses := range m {
+		for _, pos := range poses {
+			fpath := pos.Ref.GetURL().Path
+			relFile, err := filepath.Rel(specdir, fpath)
+			if err != nil {
+				return err
+			}
+			jsonpos, ok := posm[fpath][pos.Ref.GetPointer().String()]
+			if !ok {
+				return fmt.Errorf("can't find file position for %s", &pos.Ref)
+			}
+			pos.LinkLocal = fmt.Sprintf("%s:%d:%d", fpath, jsonpos.Line, jsonpos.Column)
+			if commit != "" {
+				pos.LinkGithub = "https://github.com/Azure/azure-rest-api-specs/blob/" + commit + "/specification/" + relFile + "#L" + strconv.Itoa(jsonpos.Line)
+			}
+		}
+	}
+	return nil
+}
+
+func (m ModelMap) RelativeLocalLink(specdir string) error {
+	for _, poses := range m {
+		for _, pos := range poses {
+			if pos.Ref.GetURL() != nil {
+				path, err := filepath.Rel(specdir, pos.Ref.GetURL().Path)
+				if err != nil {
+					return err
+				}
+				pos.Ref = jsonreference.MustCreateRef(path + "#" + pos.Ref.GetPointer().String())
+			}
+			if pos.LinkLocal != "" {
+				parts := strings.SplitN(pos.LinkLocal, ":", 2)
+				path, err := filepath.Rel(specdir, parts[0])
+				if err != nil {
+					return err
+				}
+				pos.LinkLocal = path + ":" + parts[1]
+			}
+			if ref := pos.RootModel.PathRef; ref.GetURL() != nil {
+				path, err := filepath.Rel(specdir, ref.GetURL().Path)
+				if err != nil {
+					return err
+				}
+				pos.RootModel.PathRef = jsonreference.MustCreateRef(path + "#" + ref.GetPointer().String())
+			}
+		}
+	}
+	return nil
 }
 
 // jsonValueMap flattens a JSON object to a single level k-v map that mapps the jsonpointer to each property to the strings representation of its value, and reverse the keys and values to be a value map.

--- a/ctrl/map.go
+++ b/ctrl/map.go
@@ -217,7 +217,11 @@ func walkJSON(node interface{}, ptks []string, fn func(node interface{}, ptrtks 
 // - Properties exist in both objects, but their values are different
 // The elements of all the returned slice are the JSON pointer of the properties.
 func compareFlattendJSON(m1, m2 map[string]interface{}) (l1 []string, l2 []string, ldiff []string) {
+	m := map[string]bool{}
 	for _, key := range append(maps.Keys(m1), maps.Keys(m2)...) {
+		m[key] = true
+	}
+	for key := range m {
 		v1, ok1 := m1[key]
 		v2, ok2 := m2[key]
 		if !ok1 {

--- a/ctrl/map_test.go
+++ b/ctrl/map_test.go
@@ -9,7 +9,7 @@ import (
 func TestJSONValueMap(t *testing.T) {
 	cases := []struct {
 		name   string
-		input  interface{}
+		input  map[string]interface{}
 		expect map[string]string
 	}{
 		{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/magodo/azure-rest-api-bridge
 
-go 1.20
+go 1.21
 
 require (
 	github.com/evanphx/json-patch/v5 v5.6.0
@@ -16,6 +16,7 @@ require (
 	github.com/rickb777/date v1.20.1
 	github.com/stretchr/testify v1.8.1
 	github.com/zclconf/go-cty v1.12.1
+	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/e
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
+github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
 github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -96,6 +97,7 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/magodo/armid v0.0.0-20230511151020-27880e5961c3 h1:ob6vk6PlChZvutcxcLnmPH/VNmJEuwz+TmCYCVtJqeA=
 github.com/magodo/armid v0.0.0-20230511151020-27880e5961c3/go.mod h1:rR8E7zfGMbmfnSQvrkFiWYdhrfTqsVSltelnZB09BwA=
 github.com/magodo/azure-rest-api-index v0.0.0-20230522080218-497fe558c02f h1:Ah7TXxbR3vhZqeI9kaoHwmmUFxv4rMVJ+YuW1BLd3To=
@@ -128,6 +130,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/gomega v1.24.0 h1:+0glovB9Jd6z3VR+ScSwQqXVTIfJcGA9UBM8yzQxhqg=
+github.com/onsi/gomega v1.24.0/go.mod h1:Z/NWtiqwBrwUt4/2loMmHL63EDLnYHmVbuBpDr2vQAg=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -179,6 +182,8 @@ golang.org/x/crypto v0.0.0-20220826181053-bd7e27e6170d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb h1:mIKbk8weKhSeLH2GmUTrvx8CjkyJmnU1wFmg59CUjFA=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/mockserver/swagger/expander.go
+++ b/mockserver/swagger/expander.go
@@ -23,12 +23,12 @@ type Expander struct {
 	emptyObjAsStr bool
 
 	// Once specified, it will be used for expanding the property. If no hit, it will also update the cache accordingly.
-	cache *expanderCache
+	cache *ExpanderCache
 }
 
 type ExpanderOption struct {
 	EmptyObjAsStr bool
-	Cache         *expanderCache
+	Cache         *ExpanderCache
 }
 
 // NewExpander create a expander for the schema referenced by the input json reference.

--- a/mockserver/swagger/expander_cache.go
+++ b/mockserver/swagger/expander_cache.go
@@ -1,18 +1,18 @@
 package swagger
 
-type expanderCache struct {
+type ExpanderCache struct {
 	m map[string]*Property
 }
 
-func NewExpanderCache() *expanderCache {
-	return &expanderCache{m: map[string]*Property{}}
+func NewExpanderCache() *ExpanderCache {
+	return &ExpanderCache{m: map[string]*Property{}}
 }
 
-func (cache *expanderCache) save(exp *Expander) {
+func (cache *ExpanderCache) save(exp *Expander) {
 	cache.m[exp.cacheKey()] = exp.root
 }
 
-func (cache *expanderCache) load(exp *Expander) bool {
+func (cache *ExpanderCache) load(exp *Expander) bool {
 	prop, ok := cache.m[exp.cacheKey()]
 	if !ok {
 		return false

--- a/mockserver/swagger/json_value.go
+++ b/mockserver/swagger/json_value.go
@@ -90,6 +90,10 @@ type JSONValuePos struct {
 	LinkGithub string            `json:"link_github,omitempty"`
 }
 
+func (pos JSONValuePos) String() string {
+	return pos.RootModel.String() + ":" + pos.Addr.String()
+}
+
 func (pos JSONValuePos) MarshalJSON() ([]byte, error) {
 	m := map[string]interface{}{
 		"root_model":  pos.RootModel,

--- a/mockserver/swagger/json_value.go
+++ b/mockserver/swagger/json_value.go
@@ -8,17 +8,20 @@ import (
 	"github.com/go-openapi/jsonreference"
 )
 
+type primitiveType interface {
+	bool | float64 | string
+}
+
 type JSONValue interface {
 	JSONValue() interface{}
+
+	// Only JSONPrimitive returns non-nil
+	JSONValuePos() *JSONValuePos
 }
 
 type JSONObject struct {
 	value map[string]JSONValue
 	pos   *JSONValuePos
-}
-
-type primitiveType interface {
-	bool | float64 | string
 }
 
 func (obj JSONObject) JSONValue() interface{} {
@@ -27,6 +30,10 @@ func (obj JSONObject) JSONValue() interface{} {
 		m[k] = v.JSONValue()
 	}
 	return m
+}
+
+func (obj JSONObject) JSONValuePos() *JSONValuePos {
+	return nil
 }
 
 type JSONArray struct {
@@ -42,6 +49,10 @@ func (arr JSONArray) JSONValue() interface{} {
 	return l
 }
 
+func (arr JSONArray) JSONValuePos() *JSONValuePos {
+	return nil
+}
+
 type JSONPrimitive[T primitiveType] struct {
 	value T
 	pos   *JSONValuePos
@@ -49,6 +60,10 @@ type JSONPrimitive[T primitiveType] struct {
 
 func (p JSONPrimitive[T]) JSONValue() interface{} {
 	return p.value
+}
+
+func (p JSONPrimitive[T]) JSONValuePos() *JSONValuePos {
+	return p.pos
 }
 
 func walkJSONValue(val JSONValue, fn func(val JSONValue)) {
@@ -161,6 +176,22 @@ func JSONValueValueMap(l ...JSONValue) (map[string]*JSONValuePos, error) {
 		}
 	}
 	return out, nil
+}
+
+func FlattenJSONValueObjectByAddr(obj JSONObject) map[string]JSONValue {
+	out := map[string]JSONValue{}
+	fn := func(val JSONValue) {
+		switch val := val.(type) {
+		case JSONPrimitive[float64]:
+			out[val.pos.Addr.String()] = val
+		case JSONPrimitive[string]:
+			out[val.pos.Addr.String()] = val
+		case JSONPrimitive[bool]:
+			out[val.pos.Addr.String()] = val
+		}
+	}
+	walkJSONValue(obj, fn)
+	return out
 }
 
 func UnmarshalJSONToJSONValue(b []byte, root *Property) (JSONValue, error) {

--- a/mockserver/swagger/property.go
+++ b/mockserver/swagger/property.go
@@ -18,6 +18,10 @@ type RootModelInfo struct {
 	Version   string            `json:"version"`
 }
 
+func (info RootModelInfo) String() string {
+	return info.PathRef.String() + ":" + info.Operation + ":" + info.Version
+}
+
 func (model RootModelInfo) MarshalJSON() ([]byte, error) {
 	m := map[string]interface{}{
 		"path_ref":  model.PathRef.String(),

--- a/mockserver/swagger/property_addr.go
+++ b/mockserver/swagger/property_addr.go
@@ -3,6 +3,8 @@ package swagger
 import (
 	"fmt"
 	"strings"
+
+	"github.com/go-openapi/jsonpointer"
 )
 
 type PropertyAddr []PropertyAddrStep
@@ -56,6 +58,24 @@ func (addr PropertyAddr) Equal(oaddr PropertyAddr) bool {
 		}
 	}
 	return true
+}
+
+func (addr PropertyAddr) ToPointer() (jsonpointer.Pointer, error) {
+	var tks []string
+	for _, step := range addr {
+		switch step.Type {
+		case PropertyAddrStepTypeIndex:
+			tks = append(tks, "0")
+		case PropertyAddrStepTypeProp:
+			tks = append(tks, step.Value)
+		case PropertyAddrStepTypeVariant:
+			continue
+		default:
+			panic(fmt.Sprintf("unknown step type: %d", step.Type))
+		}
+	}
+	ptrstr := "/" + strings.Join(tks, "/")
+	return jsonpointer.New(ptrstr)
 }
 
 func ParseAddr(input string) PropertyAddr {


### PR DESCRIPTION
`execution` block introduces new `vibrate` blocks to allow sub-executions for API model "vibration", which indicates a single property change on API model. The corresponding app model output is than compared with the base app model resulted from the base execution. Any **single** property difference between the two app models is then linked to the vibrated API model property.

This is useful to detect boolean properties.